### PR TITLE
fix: dont ignore last line of input file

### DIFF
--- a/verify.sh
+++ b/verify.sh
@@ -44,4 +44,4 @@ while IFS= read -r DOMAIN; do
         echo "$(date): O certificado SSL para $DOMAIN está válido por mais $DAYS_LEFT dias." | tee -a "$LOG_FILE"
     fi
 
-done < "$DOMAINS_FILE"
+done < <(cat $DOMAINS_FILE; printf '\n')


### PR DESCRIPTION
Using `done < <(cat $DOMAINS_FILE; printf '\n')` we can preserve the last line (by manually echoing a newline after we get the input file's content)