### PR TITLE
fix: comments, inline comments and escape comments

### DIFF
--- a/verify.sh
+++ b/verify.sh
@@ -13,10 +13,14 @@ fi
 
 # Leia os domínios do arquivo e verifique cada um
 while IFS= read -r DOMAIN; do
-    # Pule linhas em branco ou iniciadas com "#"
-    if [[ -z "$DOMAIN" || "$DOMAIN" =~ ^# ]]; then
-        continue
-    fi
+    # remover comentários
+    if [[ -n "$DOMAIN" && ${DOMAIN:0:1} == "#" ]]; then continue; fi
+
+    # remover comentários inline
+    DOMAIN=$(echo "$DOMAIN" | sed -E 's/([^\\])#.*$/\1/' | sed 's/[[:space:]]*$//')
+
+    # preservar comentários escapados
+    DOMAIN=$(echo "$DOMAIN" | sed 's/\\#/#/g')
 
     # Obtenha a data de validade do certificado SSL
     EXPIRATION_DATE=$(echo | openssl s_client -servername "$DOMAIN" -connect "$DOMAIN:443" 2>/dev/null | openssl x509 -noout -enddate | cut -d= -f2)

--- a/verify.sh
+++ b/verify.sh
@@ -48,4 +48,4 @@ while IFS= read -r DOMAIN; do
         echo "$(date): O certificado SSL para $DOMAIN está válido por mais $DAYS_LEFT dias." | tee -a "$LOG_FILE"
     fi
 
-done < "$DOMAINS_FILE"
+done < <(cat $DOMAINS_FILE; printf '\n')


### PR DESCRIPTION
This pull request aims to allow the following input file:

```txt
#meudominio.com
meudominio2.com # Dominio XYZ
meu\#dominio.com
```

On the first line, a full comment
On the second line, an "inline comment"
On the last line (not used in this context, but implemented nonetheless), an escaped # to use in the domain's URL.